### PR TITLE
Fix several bugs

### DIFF
--- a/src/doc.c
+++ b/src/doc.c
@@ -438,6 +438,7 @@ static yyjson_mut_val *tovalue_object(yyjson_mut_doc *doc, lua_State *L,
 
             if (!key) {
                 // failed to alloc memory
+                lua_pop(L, 2);
                 return NULL;
             }
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -498,6 +498,9 @@ static yyjson_mut_val *tovalue_table(yyjson_mut_doc *doc, lua_State *L, int idx,
     }
     lua_pop(L, 1);
 
+    // add to circular reference tracking before any processing
+    push_table_ref(L, refidx, idx);
+
     // if the -1st element of a table is AS_ARRAY or AS_OBJECT, the
     // table is treated as that data type.
     lua_rawgeti(L, idx, -1);
@@ -511,8 +514,6 @@ static yyjson_mut_val *tovalue_table(yyjson_mut_doc *doc, lua_State *L, int idx,
         }
     }
     lua_pop(L, 1);
-
-    push_table_ref(L, refidx, idx);
 
     if (lauxh_rawlen(L, idx)) {
 TREAT_AS_ARRAY:

--- a/src/doc.c
+++ b/src/doc.c
@@ -648,10 +648,10 @@ static void build_path_string(lua_State *L, int pathidx, const char *prefix)
             }
 
             if (needs_esc) {
-                lua_pop(L, 1);
                 luaL_addchar(&b, '[');
                 addquoted(&b, k, klen);
                 luaL_addchar(&b, ']');
+                lua_pop(L, 1);
                 continue;
             }
             // Object key, use dot (assuming simple string keys for simplicity)

--- a/src/doc.c
+++ b/src/doc.c
@@ -392,7 +392,7 @@ static yyjson_mut_val *tovalue_array(yyjson_mut_doc *doc, lua_State *L, int idx,
                 // fill spaces
                 for (lua_Integer n = 1; n < skip; n++) {
                     yyjson_mut_val *nullval = yyjson_mut_null(doc);
-                    if (!val) {
+                    if (!nullval) {
                         // failed to alloc memory
                         lua_pop(L, 2);
                         return NULL;


### PR DESCRIPTION
This pull request focuses on improving memory management and handling circular references in the `src/doc.c` file. The most notable changes include fixing memory allocation checks, adjusting the order of operations for reference tracking, and ensuring proper stack cleanup in Lua.

### Memory management improvements:

* Fixed a typo in a null pointer check by replacing `if (!val)` with `if (!nullval)` in the `tovalue_array` function to correctly handle memory allocation failures.
* Added a missing `lua_pop(L, 2)` call in the `tovalue_object` function to ensure proper cleanup of the Lua stack when memory allocation for a key fails.

### Circular reference handling:

* Moved the call to `push_table_ref` earlier in the `tovalue_table` function to add circular reference tracking before any processing of the table begins.
* Removed a redundant call to `push_table_ref` later in the `tovalue_table` function to avoid duplicate reference tracking.

### Code consistency:

* Adjusted the position of a `lua_pop` call in the `build_path_string` function to align with the logical flow of the code, ensuring proper stack cleanup after handling escaped keys.