### PR TITLE
Upgrade bundled yyjson to 0.12.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 
 lua bindings for https://github.com/ibireme/yyjson.
 
+This release bundles [yyjson 0.12.0](https://github.com/ibireme/yyjson/releases/tag/0.12.0).
+
 
 ## Installation
 
@@ -152,7 +154,8 @@ encode a Lua value `v` to a JSON string.
 | `yyjson.WRITE_INF_AND_NAN_AS_NULL` | Write `inf` and `nan` number as `null` literal.<br>This flag will override `yyjson.WRITE_ALLOW_INF_AND_NAN` flag. |
 | `yyjson.WRITE_ALLOW_INVALID_UNICODE` | Allow invalid unicode when encoding string values (non-standard).<br>Invalid characters in string value will be copied byte by byte.<br>If `WRITE_ESCAPE_UNICODE` flag is also set, invalid character will be escaped as `U+FFFD` (replacement character).<br>This flag does not affect the performance of correctly encoded strings. |
 | `yyjson.WRITE_PRETTY_TWO_SPACES` | Write JSON pretty with 2 space indent.<br>This flag will override  `WRITE_PRETTY` flag. |
-| `yyjson.WRITE_NEWLINE_AT_END` | Adds a newline character `\n` at the end of the JSON.<br>This can be helpful for text editors or NDJSON | 
+| `yyjson.WRITE_NEWLINE_AT_END` | Adds a newline character `\n` at the end of the JSON.<br>This can be helpful for text editors or NDJSON |
+| `yyjson.WRITE_FP_TO_FLOAT` | Write floating-point numbers using single-precision (`float`) instead of double-precision. Can produce shorter output for values that fit. |
 
 
 **Returns**
@@ -198,6 +201,13 @@ decode a JSON string `s` to a Lua value.
 | `yyjson.READ_NUMBER_AS_RAW` | Read number as raw string (value with `YYJSON_TYPE_RAW` type), `inf`/`nan` literal is also read as raw with `ALLOW_INF_AND_NAN` flag. |
 | `yyjson.READ_ALLOW_INVALID_UNICODE` | Allow reading invalid unicode when parsing string values.<br>Invalid characters will be allowed to appear in the string values, but invalid escape sequences will still be reported as errors.<br>This flag does not affect the performance of correctly encoded strings.<br>**@warning** Strings in JSON values may contain incorrect encoding when this option is used, you need to handle these strings carefully to avoid security risks. |
 | `yyjson.READ_BIGNUM_AS_RAW` | Read big numbers as raw strings.<br>These big numbers include integers that cannot be represented by `int64_t` and `uint64_t`, and floating-point numbers that cannot be represented by finite `double`.<br>The flag will be overridden by `yyjson.READ_NUMBER_AS_RAW` flag. |
+| `yyjson.READ_ALLOW_BOM` | Allow a leading UTF-8 byte order mark (`BOM`) before the JSON document. The `BOM` is consumed and ignored. |
+| `yyjson.READ_ALLOW_EXT_NUMBER` | Allow extended numeric formats: hexadecimal (`0x7B`), explicit positive sign (`+1`), leading dot (`.5`), trailing dot (`5.`). Conforms to JSON5. |
+| `yyjson.READ_ALLOW_EXT_ESCAPE` | Allow extended escape sequences inside strings, such as `\a`, `\0`, `\v`, and `\xNN` hex escapes. Conforms to JSON5. |
+| `yyjson.READ_ALLOW_EXT_WHITESPACE` | Allow extended whitespace characters such as `\v` and `\u2028` in addition to the standard space, tab, CR and LF. Conforms to JSON5. |
+| `yyjson.READ_ALLOW_SINGLE_QUOTED_STR` | Allow single-quoted strings such as `'abc'` in addition to double-quoted strings. Conforms to JSON5. |
+| `yyjson.READ_ALLOW_UNQUOTED_KEY` | Allow unquoted object keys when the key is a valid ECMAScript identifier, such as `{a:1}`. Conforms to JSON5. |
+| `yyjson.READ_JSON5` | Enable full JSON5 support by combining all relaxed read flags above plus comments, trailing commas, and `inf`/`nan` literals. |
 
 **Returns**
 

--- a/src/doc.c
+++ b/src/doc.c
@@ -1146,6 +1146,37 @@ LUALIB_API int luaopen_yyjson_doc(lua_State *L)
      * overridden by `YYJSON_READ_NUMBER_AS_RAW` flag. */
     lauxh_pushint2tbl(L, "READ_BIGNUM_AS_RAW", YYJSON_READ_BIGNUM_AS_RAW);
 
+    /** Allow a leading UTF-8 byte order mark (BOM) before the JSON document.
+        BOM is consumed and ignored. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_BOM", YYJSON_READ_ALLOW_BOM);
+
+    /** Allow extended numeric formats: hexadecimal (0x7B), explicit positive
+        sign (+1), leading dot (.5), trailing dot (5.). Conforms to JSON5. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_EXT_NUMBER", YYJSON_READ_ALLOW_EXT_NUMBER);
+
+    /** Allow extended escape sequences inside strings, such as \a, \0, \v,
+        and \xNN hex escapes. Conforms to JSON5. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_EXT_ESCAPE", YYJSON_READ_ALLOW_EXT_ESCAPE);
+
+    /** Allow extended whitespace characters such as \v and \u2028 in addition
+        to the standard space, tab, CR and LF. Conforms to JSON5. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_EXT_WHITESPACE",
+                      YYJSON_READ_ALLOW_EXT_WHITESPACE);
+
+    /** Allow single-quoted strings such as 'abc' in addition to double-quoted
+        strings. Conforms to JSON5. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_SINGLE_QUOTED_STR",
+                      YYJSON_READ_ALLOW_SINGLE_QUOTED_STR);
+
+    /** Allow unquoted object keys when the key is a valid ECMAScript
+        identifier, such as {a:1}. Conforms to JSON5. */
+    lauxh_pushint2tbl(L, "READ_ALLOW_UNQUOTED_KEY",
+                      YYJSON_READ_ALLOW_UNQUOTED_KEY);
+
+    /** Enable full JSON5 support by combining all relaxed read flags above
+        plus comments, trailing commas, and inf/nan literals. */
+    lauxh_pushint2tbl(L, "READ_JSON5", YYJSON_READ_JSON5);
+
     /** Result code for JSON reader. */
     /** Success, no error. */
     lauxh_pushint2tbl(L, "READ_SUCCESS", YYJSON_READ_SUCCESS);
@@ -1223,6 +1254,10 @@ LUALIB_API int luaopen_yyjson_doc(lua_State *L)
     /** Adds a newline character `\n` at the end of the JSON.
         This can be helpful for text editors or NDJSON. */
     lauxh_pushint2tbl(L, "WRITE_NEWLINE_AT_END", YYJSON_WRITE_NEWLINE_AT_END);
+
+    /** Write floating-point numbers using single-precision (float) instead of
+        double-precision. Can produce shorter output for values that fit. */
+    lauxh_pushint2tbl(L, "WRITE_FP_TO_FLOAT", YYJSON_WRITE_FP_TO_FLOAT);
 
     /** Result code for JSON writer */
     /** Success, no error. */

--- a/test/yyjson_test.lua
+++ b/test/yyjson_test.lua
@@ -227,3 +227,102 @@ function testcase.memory_limit_decode()
     assert.is_nil(v)
     assert.match(err, 'ENOMEM')
 end
+
+function testcase.decode_with_bom()
+    -- test that READ_ALLOW_BOM consumes a UTF-8 BOM before the JSON document
+    local s = '\239\187\191{"a":1}'
+
+    -- without the flag, the BOM byte is rejected
+    local v, err = yyjson.decode(s)
+    assert.is_nil(v)
+    assert.match(err, 'EINVAL')
+
+    -- with the flag, the BOM is ignored and parsing succeeds
+    v, err = yyjson.decode(s, nil, nil, nil, yyjson.READ_ALLOW_BOM)
+    assert.is_nil(err)
+    assert.equal(v, {
+        a = 1,
+    })
+end
+
+function testcase.decode_single_quoted_string()
+    local s = "{\"key\":'value'}"
+
+    -- without the flag, single-quoted strings are rejected
+    local v, err = yyjson.decode(s)
+    assert.is_nil(v)
+    assert.match(err, 'EINVAL')
+
+    -- with the flag, single-quoted strings are accepted
+    v, err =
+        yyjson.decode(s, nil, nil, nil, yyjson.READ_ALLOW_SINGLE_QUOTED_STR)
+    assert.is_nil(err)
+    assert.equal(v, {
+        key = 'value',
+    })
+end
+
+function testcase.decode_unquoted_key()
+    local s = '{key:"value"}'
+
+    -- without the flag, unquoted keys are rejected
+    local v, err = yyjson.decode(s)
+    assert.is_nil(v)
+    assert.match(err, 'EINVAL')
+
+    -- with the flag, unquoted keys are accepted
+    v, err = yyjson.decode(s, nil, nil, nil, yyjson.READ_ALLOW_UNQUOTED_KEY)
+    assert.is_nil(err)
+    assert.equal(v, {
+        key = 'value',
+    })
+end
+
+function testcase.decode_ext_number()
+    local s = '{"hex":0x7B,"plus":+1.5}'
+
+    -- without the flag, hex and explicit positive sign are rejected
+    local v, err = yyjson.decode(s)
+    assert.is_nil(v)
+    assert.match(err, 'EINVAL')
+
+    -- with the flag, extended number formats are accepted
+    v, err = yyjson.decode(s, nil, nil, nil, yyjson.READ_ALLOW_EXT_NUMBER)
+    assert.is_nil(err)
+    assert.equal(v.hex, 123)
+    assert.equal(v.plus, 1.5)
+end
+
+function testcase.decode_json5()
+    local s = "{ a: 'hello', b: 1, /* comment */ }"
+
+    -- without the flag, JSON5 syntax is rejected
+    local v, err = yyjson.decode(s)
+    assert.is_nil(v)
+    assert.match(err, 'EINVAL')
+
+    -- READ_JSON5 enables comments, trailing commas, single-quoted strings,
+    -- unquoted keys, extended numbers/escapes/whitespace and inf/nan literals
+    -- in one combined flag
+    v, err = yyjson.decode(s, nil, nil, nil, yyjson.READ_JSON5)
+    assert.is_nil(err)
+    assert.equal(v, {
+        a = 'hello',
+        b = 1,
+    })
+end
+
+function testcase.encode_fp_to_float()
+    -- pick a value with enough precision to show the difference between
+    -- double and float output
+    local v = 3.14159265358979
+
+    -- default encoding writes the value with double precision
+    local s = assert(yyjson.encode(v))
+    assert.equal(s, '3.14159265358979')
+
+    -- WRITE_FP_TO_FLOAT downcasts to single precision, producing the
+    -- shorter representation that round-trips through float
+    s = assert(yyjson.encode(v, nil, yyjson.WRITE_FP_TO_FLOAT))
+    assert.equal(s, '3.1415927')
+end


### PR DESCRIPTION
This pull request updates the Lua bindings to yyjson by bundling yyjson 0.12.0 and adding support for new read and write flags, especially for JSON5 compatibility and floating-point encoding. The documentation and tests have been updated to reflect these new features.

**Upgrade to yyjson 0.12.0:**

* The bundled `yyjson` submodule has been updated to version 0.12.0, bringing in new features and bug fixes from upstream. [[1]](diffhunk://#diff-df0e98ea269874c7831ea14c5c875705d4e4835a2e5d3c9ff379d0779d18dfd7L1-R1) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R8-R9)

**New read flags for JSON5 and extended JSON support:**

* Added support for multiple new read flags in the Lua API (`src/doc.c`): `READ_ALLOW_BOM`, `READ_ALLOW_EXT_NUMBER`, `READ_ALLOW_EXT_ESCAPE`, `READ_ALLOW_EXT_WHITESPACE`, `READ_ALLOW_SINGLE_QUOTED_STR`, `READ_ALLOW_UNQUOTED_KEY`, and `READ_JSON5`, enabling parsing of JSON5 and other non-standard JSON features.
* Updated documentation to describe these new read flags and their behavior.
* Added tests for the new read flags, verifying correct handling of BOM, single-quoted strings, unquoted keys, extended numbers, and full JSON5 parsing.

**New write flag for floating-point encoding:**

* Added support for the `WRITE_FP_TO_FLOAT` flag, allowing floating-point numbers to be encoded as single-precision floats, which can produce shorter output.
* Updated documentation and added a test to demonstrate the effect of this flag on output precision. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R158) [[2]](diffhunk://#diff-90ee69bbc5fcaed5bb82205270c8c6335ed1370206bdcf202a4d31745cb68051R230-R328)